### PR TITLE
Minor refactoring

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -54,7 +54,7 @@ func (cache *Cache) startExpirationProcessing() {
 		if cache.priorityQueue.Len() > 0 {
 			sleepTime = cache.priorityQueue.items[0].expireAt.Sub(time.Now())
 			if sleepTime < 0 {
-				sleepTime = time.Duration(time.Hour)
+				sleepTime = time.Hour
 			}
 			if cache.ttl > 0 {
 				sleepTime = min(sleepTime, cache.ttl)
@@ -63,7 +63,7 @@ func (cache *Cache) startExpirationProcessing() {
 		} else if cache.ttl > 0 {
 			sleepTime = cache.ttl
 		} else {
-			sleepTime = time.Duration(1 * time.Hour)
+			sleepTime = time.Hour
 		}
 
 		cache.expirationTime = time.Now().Add(sleepTime)
@@ -224,7 +224,7 @@ func NewCache() *Cache {
 	cache := &Cache{
 		items:                  make(map[string]*item),
 		priorityQueue:          newPriorityQueue(),
-		expirationNotification: make(chan bool, 1),
+		expirationNotification: make(chan bool),
 		expirationTime:         time.Now(),
 	}
 	go cache.startExpirationProcessing()

--- a/item.go
+++ b/item.go
@@ -40,6 +40,5 @@ func (item *item) expired() bool {
 	if item.ttl <= 0 {
 		return false
 	}
-	expired := item.expireAt.Before(time.Now())
-	return expired
+	return item.expireAt.Before(time.Now())
 }

--- a/priority_queue.go
+++ b/priority_queue.go
@@ -2,7 +2,6 @@ package ttlcache
 
 import (
 	"container/heap"
-	"time"
 )
 
 func newPriorityQueue() *priorityQueue {
@@ -41,15 +40,13 @@ func (pq priorityQueue) Len() int {
 
 // Less will consider items with time.Time default value (epoch start) as more than set items.
 func (pq priorityQueue) Less(i, j int) bool {
-	var empty time.Time
-	if pq.items[i].expireAt == empty {
+	if pq.items[i].expireAt.IsZero() {
 		return false
 	}
-	if pq.items[j].expireAt == empty {
+	if pq.items[j].expireAt.IsZero() {
 		return true
 	}
-	less := pq.items[i].expireAt.Before(pq.items[j].expireAt)
-	return less
+	return pq.items[i].expireAt.Before(pq.items[j].expireAt)
 }
 
 func (pq priorityQueue) Swap(i, j int) {


### PR DESCRIPTION
- Remove unnecessary time.Duration calls.
- Remove unnecessary declarations right before return statements.
- Use time package IsZero() for empty time comparison for clarity.