### PR TITLE
Froodian fix data race

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -22,7 +22,7 @@ type Cache struct {
 	priorityQueue          *priorityQueue
 	expirationNotification chan bool
 	expirationTime         time.Time
-	skipTtlExtension       bool
+	skipTTLExtension       bool
 }
 
 func (cache *Cache) getItem(key string) (*item, bool) {
@@ -39,7 +39,7 @@ func (cache *Cache) getItem(key string) (*item, bool) {
 			item.ttl = cache.ttl
 		}
 
-		if !cache.skipTtlExtension {
+		if !cache.skipTTLExtension {
 			item.touch()
 		}
 		cache.priorityQueue.update(item)
@@ -225,7 +225,7 @@ func (cache *Cache) SetNewItemCallback(callback expireCallback) {
 // no longer extend TTL of items when they are retrieved using Get, or when their expiration condition is evaluated
 // using SetCheckExpirationCallback.
 func (cache *Cache) SkipTtlExtensionOnHit(value bool) {
-	cache.skipTtlExtension = value
+	cache.skipTTLExtension = value
 }
 
 // Purge will remove all entries


### PR DESCRIPTION
If you add the new test to the code on `master` and run `go test ./... -race -count=1 -timeout=1m -run .` you'll see it fail with

```
WARNING: DATA RACE
Write at 0x00c0000dc380 by goroutine 17:
  github.com/diegobernardes/ttlcache.(*Cache).SetWithTTL()
      /Users/ian/go/src/github.com/diegobernardes/ttlcache/cache.go:140 +0xa0
  github.com/diegobernardes/ttlcache.TestCache_SkipTtlExtensionOnHit_ForRacesAcrossGoroutines.func1.1()
      /Users/ian/go/src/github.com/diegobernardes/ttlcache/cache.go:131 +0x7d

Previous read at 0x00c0000dc380 by goroutine 16:
  github.com/diegobernardes/ttlcache.TestCache_SkipTtlExtensionOnHit_ForRacesAcrossGoroutines.func2.1()
      /Users/ian/go/src/github.com/diegobernardes/ttlcache/cache.go:172 +0x94
```

this resolves that.