### PR TITLE
address memory usage issue in time.After()

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -74,8 +74,10 @@ func (cache *Cache) startExpirationProcessing() {
 		cache.expirationTime = time.Now().Add(sleepTime)
 		cache.mutex.Unlock()
 
+		timer := time.NewTimer(sleepTime)
 		select {
-		case <-time.After(sleepTime):
+		case <-timer.C:
+			timer.Stop()
 			cache.mutex.Lock()
 			if cache.priorityQueue.Len() == 0 {
 				cache.mutex.Unlock()
@@ -111,6 +113,7 @@ func (cache *Cache) startExpirationProcessing() {
 			cache.mutex.Unlock()
 
 		case <-cache.expirationNotification:
+			timer.Stop()
 			continue
 		}
 	}


### PR DESCRIPTION
I observed a continuous increase in memory usage when making heavy use of the cache with a long global TTL set. My usage pattern was mostly setting and quickly deleting values again (manually), and my intention was to use the TTL only to purge corner cases which were not cleaned up by my own code.

Profiling revealed that the memory in use is mostly timers:
```
$ go tool pprof foo
[...]
Time: Apr 26, 2019 at 3:09pm (CEST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top20
Showing nodes accounting for 1181.16MB, 99.36% of 1188.80MB total
Dropped 11 nodes (cum <= 5.94MB)
Showing top 20 nodes out of 24
      flat  flat%   sum%        cum   cum%
  983.58MB 82.74% 82.74%  1034.31MB 87.00%  time.NewTimer
   50.73MB  4.27% 87.00%    50.73MB  4.27%  time.startTimer

[...]
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                         1034.31MB   100% |   github.com/ReneKroon/ttlcache.(*Cache).startExpirationProcessing
  983.58MB 82.74% 82.74%  1034.31MB 87.00%                | time.NewTimer
                                           50.73MB  4.90% |   time.startTimer
----------------------------------------------------------+-------------
```

This was likely to a common quirk with `time.After()`, see e.g. [1] and more.Some minor refactoring (see diff) resulted in the same behaviour but without excessive memory usage. Tests complete with no problem.

[1] https://medium.com/@oboturov/golang-time-after-is-not-garbage-collected-4cbc94740082