### PR TITLE
Added cache limit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 TTLCache is a simple key/value cache in golang with the following functions:
 
 1. Expiration of items based on time, or custom function
-2. Loader function to retrieve missing keys can be provided. Additional `Get` calls on the same key block while fetching is in progress (groupcache style). 
+2. Loader function to retrieve missing keys can be provided. Additional `Get` calls on the same key block while fetching is in progress (groupcache style).
 3. Individual expiring time or global expiring time, you can choose
 4. Auto-Extending expiration on `Get` -or- DNS style TTL, see `SkipTTLExtensionOnHit(bool)`
 5. Can trigger callback on key expiration
@@ -21,7 +21,7 @@ Note (issue #25): by default, due to historic reasons, the TTL will be reset on 
 [![GitHub issues](https://img.shields.io/github/issues/ReneKroon/ttlcache.svg)](https://github.com/ReneKroon/ttlcache/issues)
 [![license](https://img.shields.io/github/license/ReneKroon/ttlcache.svg?maxAge=2592000)](https://github.com/ReneKroon/ttlcache/LICENSE)
 
-## Usage 
+## Usage
 
 You can copy it as a full standalone demo program.
 
@@ -106,3 +106,4 @@ The main differences are:
 3. The expiration can be either global or per item
 4. Items can exist without expiration time (time.Zero)
 5. Expirations and callbacks are realtime. Don't have a pooling time to check anymore, now it's done with a heap.
+6. A cache count limiter

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,12 +1,12 @@
 package ttlcache_test
 
 import (
+	"go.uber.org/goleak"
 	"math/rand"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"go.uber.org/goleak"
 
 	"fmt"
 	"sync"
@@ -668,4 +668,19 @@ func TestCache_Purge(t *testing.T) {
 		assert.Equal(t, 0, cache.Count(), "Cache should be empty")
 	}
 
+}
+
+func TestCache_Limit(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCache()
+	defer cache.Close()
+
+	cache.SetTTL(time.Duration(100 * time.Second))
+	cache.SetCacheSizeLimit(10)
+
+	for i := 0; i < 100; i++ {
+		cache.Set("key"+strconv.FormatInt(int64(i), 10), "value")
+	}
+	assert.Equal(t, 10, cache.Count(), "Cache should equal to limit")
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -683,4 +683,9 @@ func TestCache_Limit(t *testing.T) {
 		cache.Set("key"+strconv.FormatInt(int64(i), 10), "value")
 	}
 	assert.Equal(t, 10, cache.Count(), "Cache should equal to limit")
+	for i := 90; i < 100; i++ {
+		key := "key" + strconv.FormatInt(int64(i), 10)
+		val, _ := cache.Get(key)
+		assert.Equal(t, "value", val, "Cache should be set [key90, key99]")
+	}
 }

--- a/priority_queue_test.go
+++ b/priority_queue_test.go
@@ -69,21 +69,21 @@ func TestPriorityQueueRemove(t *testing.T) {
 		if item == nil {
 			break
 		}
-		assert.NotEqual(t, itemRemove.key, item.key, "This element was not suppose to be in the queue")
+		assert.NotEqual(t, itemRemove.key, item.key, "This element was not supposed to be in the queue")
 	}
 
-	assert.Equal(t, queue.Len(), 0, "The queue is suppose to be with 0 items")
+	assert.Equal(t, queue.Len(), 0, "The queue is supposed to be with 0 items")
 }
 
 func TestPriorityQueueUpdate(t *testing.T) {
 	queue := newPriorityQueue()
 	item := newItem("key", "data", 1*time.Second)
 	queue.push(item)
-	assert.Equal(t, queue.Len(), 1, "The queue is suppose to be with 1 item")
+	assert.Equal(t, queue.Len(), 1, "The queue is supposed to be with 1 item")
 
 	item.key = "newKey"
 	queue.update(item)
 	newItem := queue.pop()
 	assert.Equal(t, newItem.key, "newKey", "The item key didn't change")
-	assert.Equal(t, queue.Len(), 0, "The queue is suppose to be with 0 items")
+	assert.Equal(t, queue.Len(), 0, "The queue is supposed to be with 0 items")
 }


### PR DESCRIPTION
This PR adds a cache limiter.

This is something that we need to keep the cache from growing too large if we have a spike in caching.