### PR TITLE
improve the performance of getwithttl in extend TTL case

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -312,7 +312,11 @@ func (cache *Cache) GetByLoaderWithTtl(key string, customLoaderFunction LoaderFu
 	if exists {
 		cache.metrics.Retrievals++
 		dataToReturn = item.data
-		ttlToReturn = time.Until(item.expireAt)
+		if !cache.skipTTLExtension {
+			ttlToReturn = item.ttl
+		} else {
+			ttlToReturn = time.Until(item.expireAt)
+		}
 		if ttlToReturn < 0 {
 			ttlToReturn = 0
 		}

--- a/cache_test.go
+++ b/cache_test.go
@@ -854,6 +854,15 @@ func TestCacheGetWithTTL(t *testing.T) {
 	assert.NotNil(t, data, "Expected data to be not nil")
 	assert.Equal(t, nil, exists, "Expected data to exist")
 	assert.Equal(t, "world", (data.(string)), "Expected data content to be 'world'")
+	assert.Equal(t, ttl, orgttl, "Expected item TTL to be original TTL")
+
+	cache.SkipTTLExtensionOnHit(true)
+	cache.SetWithTTL("hello", "world", orgttl)
+	time.Sleep(10 * time.Millisecond)
+	data, ttl, exists = cache.GetWithTTL("hello")
+	assert.NotNil(t, data, "Expected data to be not nil")
+	assert.Equal(t, nil, exists, "Expected data to exist")
+	assert.Equal(t, "world", (data.(string)), "Expected data content to be 'world'")
 	assert.Less(t, ttl, orgttl, "Expected item TTL to be less than the original TTL")
 	assert.NotEqual(t, int(ttl), 0, "Expected item TTL to be not 0")
 }


### PR DESCRIPTION
As we know, `getwithttl` will extend the TTL of the item when retrieving the cache item if the `SkipTTLExtensionOnHit` flag is not true. 
https://github.com/ReneKroon/ttlcache/blob/66a3c287ad122c46ae5d2b2caa65d9baef22c74d/cache.go#L94-L96
Because of this, it may be a better way to return the TTL in this case by using the item's original TTL directly rather than recalculating it.
