### PR TITLE
Bug-fix/fixes memory leaks in priority queue

### DIFF
--- a/priority_queue.go
+++ b/priority_queue.go
@@ -78,6 +78,8 @@ func (pq *priorityQueue) Pop() interface{} {
 	n := len(old)
 	item := old[n-1]
 	item.queueIndex = -1
+	// de-reference the element to be popped for Garbage Collector to de-allocate the memory
+	old[n-1] = nil
 	pq.items = old[0 : n-1]
 	return item
 }


### PR DESCRIPTION
The Pop() in the implementation of the priorityQueue is re-slicing the items array. This lead to the slice being shrunk down but the reference to the item is still maintained by the underlying array. Because of this, the golang GC assumes that the item was still accessible and thus didn’t deallocate it. This is resulting in memory leaks when the application is run for very long sessions. More information can be found [on this SO entry](https://stackoverflow.com/questions/28432658/does-go-garbage-collect-parts-of-slices/28432812#28432812).